### PR TITLE
Build Fix: Update Lambda Node Version

### DIFF
--- a/amplify/backend/analytics/reactnotes/pinpoint-cloudformation-template.json
+++ b/amplify/backend/analytics/reactnotes/pinpoint-cloudformation-template.json
@@ -199,7 +199,7 @@
                     }
                 },
                 "Handler": "index.handler",
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs10.16.3",
                 "Timeout": "300",
                 "Role": {
                     "Fn::GetAtt": [


### PR DESCRIPTION
There was an error when building this project in AWS Amplify Console.
Update the Lambda runtime version from Node 6.x to 10.x.